### PR TITLE
Implement spawn to execute evaluation

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,9 @@
       "dependencies": {
         "@colors/colors": "^1.6.0",
         "@commander-js/extra-typings": "^13.1.0",
+        "@types/cross-spawn": "^6.0.6",
         "@types/node": "^22.15.14",
+        "cross-spawn": "^7.0.6",
         "extract-zip": "^2.0.1",
         "https-proxy-agent": "^7.0.6n",
         "node-fetch": "^3.3.2",
@@ -412,6 +414,15 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/@types/cross-spawn": {
+      "version": "6.0.6",
+      "resolved": "https://registry.npmjs.org/@types/cross-spawn/-/cross-spawn-6.0.6.tgz",
+      "integrity": "sha512-fXRhhUkG4H3TQk5dBhQ7m/JDdSNHKwR2BBia62lhwEIq9xGiQKLxd6LymNhn47SjXhsUEPmxi+PKw2OkW4LLjA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
       }
     },
     "node_modules/@types/estree": {
@@ -3643,6 +3654,14 @@
       "requires": {
         "@nodelib/fs.scandir": "2.1.5",
         "fastq": "^1.6.0"
+      }
+    },
+    "@types/cross-spawn": {
+      "version": "6.0.6",
+      "resolved": "https://registry.npmjs.org/@types/cross-spawn/-/cross-spawn-6.0.6.tgz",
+      "integrity": "sha512-fXRhhUkG4H3TQk5dBhQ7m/JDdSNHKwR2BBia62lhwEIq9xGiQKLxd6LymNhn47SjXhsUEPmxi+PKw2OkW4LLjA==",
+      "requires": {
+        "@types/node": "*"
       }
     },
     "@types/estree": {

--- a/package.json
+++ b/package.json
@@ -34,7 +34,9 @@
   "dependencies": {
     "@colors/colors": "^1.6.0",
     "@commander-js/extra-typings": "^13.1.0",
+    "@types/cross-spawn": "^6.0.6",
     "@types/node": "^22.15.14",
+    "cross-spawn": "^7.0.6",
     "extract-zip": "^2.0.1",
     "https-proxy-agent": "^7.0.6n",
     "node-fetch": "^3.3.2",

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -84,7 +84,7 @@ export function getCmdArguments() {
         args.push('--scan=package-lock.json');
     }
 
-    return args.join(' ');
+    return args;
 }
 
 function hasCmdArg(args: string[], argPrefix: string) {

--- a/src/executor.ts
+++ b/src/executor.ts
@@ -1,48 +1,47 @@
 import {cleanDir, getJavaToolOptions, log} from "./utils.js";
 import path from "path";
-import {exec} from "child_process";
+import {SpawnOptions, SpawnSyncOptionsWithBufferEncoding, SpawnSyncOptionsWithStringEncoding} from "child_process";
+import spawn from "cross-spawn";
 import colors from '@colors/colors/safe.js';
 import {getCmdArguments} from "./cli.js";
 
 export async function runDependencyCheck(executable: string, outDir: string) {
+    log('Dependency-Check Core path:', executable);
     await cleanDir(path.resolve(process.cwd(), outDir));
 
     const env = process.env;
     if (getJavaToolOptions()) {
         env.JAVA_TOOL_OPTIONS = getJavaToolOptions();
     }
-    const opts = {
+
+    const versionSpawnOpts: SpawnOptions | SpawnSyncOptionsWithBufferEncoding | SpawnSyncOptionsWithStringEncoding = {
         cwd: path.resolve(process.cwd()),
-        maxBuffer: 1024 * 1024 * 50,
-        env: env,
+        shell: false,
+        encoding: 'utf-8'
+    };
+    const dependencyCheckSpawnOpts: SpawnOptions = {
+        cwd: path.resolve(process.cwd()),
+        shell: false,
+        stdio: 'inherit'
     };
 
-    const cmdVersion = `${executable} --version`;
-    const cmd = `${executable} ${getCmdArguments()}`;
+    const versionCmdArguments = ['--version'];
+    const versionCmd = `${executable} ${versionCmdArguments.join(' ')}`;
 
-    // TODO: handle system out/err
-    exec(cmdVersion, opts, (err, _stdout, _stderr) => {
-        if (err) {
-            console.error(err);
-            console.error(_stderr);
-            return;
-        }
+    log('Running command:\n', versionCmd);
+    const versionSpawn = spawn.sync(executable, versionCmdArguments, versionSpawnOpts);
+    const versionSpawnResult = versionSpawn.stdout;
 
-        const re = /\D* (\d+\.\d+\.\d+).*/;
-        const versionMatch = re.exec(_stdout);
+    const re = /\D* (\d+\.\d+\.\d+).*/;
+    const versionMatch = re.exec(versionSpawnResult);
+    log('Dependency-Check Core version:', versionMatch ? versionMatch[1] : versionSpawnResult);
 
-        log('Dependency-Check Core path:', executable);
-        log('Dependency-Check Core version:', versionMatch ? versionMatch[1] : _stdout);
+    const dependencyCheckCmdArguments = getCmdArguments();
+    const dependencyCheckCmd = `${executable} ${dependencyCheckCmdArguments.join(' ')}`;
 
-        log('Running command:\n', cmd);
-        exec(cmd, opts, (err, _stdout, _stderr) => {
-            if (err) {
-                console.error(err);
-                console.error(_stderr);
-                return;
-            }
-
-            log(colors.green('Done.'));
-        })
-    })
+    log('Running command:\n', dependencyCheckCmd);
+    const dependencyCheckSpawn = spawn(executable, dependencyCheckCmdArguments, dependencyCheckSpawnOpts);
+    dependencyCheckSpawn.on('close', () => {
+        log(colors.green('Done.'));
+    });
 }


### PR DESCRIPTION
Closes https://github.com/atwupack/owasp-dependency-check/issues/2

### Validations

- ✅ Run `npm run build`
- ✅ Run `npm run eslint`

### Additional notes

- `exec` is similar to `spawn` with `shell: true` option. However, that is [not recommended](https://nodejs.org/en/blog/vulnerability/april-2024-security-releases-2)
- [cross-spawn](https://www.npmjs.com/package/cross-spawn) was included because `spawn` + `shell: false` fails in Windows with `spawn EINVAL`. `cross-spawn` helps with this issue.
- ~I only switch one of the 2 `exec`. The first one is "fine" because it is "quickly enough" (let me know if full migration is desired).~
