### PR TITLE
GH-28: upgrade commander to version 14

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "@colors/colors": "^1.6.0",
-        "@commander-js/extra-typings": "^13.1.0",
+        "@commander-js/extra-typings": "^14.0.0",
         "cross-spawn": "^7.0.6",
         "extract-zip": "^2.0.1",
         "purify-ts": "^2.1.0",
@@ -49,12 +49,12 @@
       }
     },
     "node_modules/@commander-js/extra-typings": {
-      "version": "13.1.0",
-      "resolved": "https://registry.npmjs.org/@commander-js/extra-typings/-/extra-typings-13.1.0.tgz",
-      "integrity": "sha512-q5P52BYb1hwVWE6dtID7VvuJWrlfbCv4klj7BjUUOqMz4jbSZD4C9fJ9lRjL2jnBGTg+gDDlaXN51rkWcLk4fg==",
+      "version": "14.0.0",
+      "resolved": "https://registry.npmjs.org/@commander-js/extra-typings/-/extra-typings-14.0.0.tgz",
+      "integrity": "sha512-hIn0ncNaJRLkZrxBIp5AsW/eXEHNKYQBh0aPdoUqNgD+Io3NIykQqpKFyKcuasZhicGaEZJX/JBSIkZ4e5x8Dg==",
       "license": "MIT",
       "peerDependencies": {
-        "commander": "~13.1.0"
+        "commander": "~14.0.0"
       }
     },
     "node_modules/@emnapi/core": {
@@ -1082,13 +1082,13 @@
       "license": "MIT"
     },
     "node_modules/commander": {
-      "version": "13.1.0",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-13.1.0.tgz",
-      "integrity": "sha512-/rFeCpNJQbhSZjGVwO9RFV3xPqbnERS8MmIQzCtD/zl6gpJuV/bMLuN92oG3F7d8oDEHHRrujSXNUr8fpjntKw==",
+      "version": "14.0.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-14.0.0.tgz",
+      "integrity": "sha512-2uM9rYjPvyq39NwLRqaiLtWHyDC1FvryJDa2ATTVims5YAS4PupsEQsDvP14FqhFr0P49CYDugi59xaxJlTXRA==",
       "license": "MIT",
       "peer": true,
       "engines": {
-        "node": ">=18"
+        "node": ">=20"
       }
     },
     "node_modules/concat-map": {
@@ -2626,9 +2626,9 @@
       "integrity": "sha512-Ir+AOibqzrIsL6ajt3Rz3LskB7OiMVHqltZmspbW/TJuTVuyOMirVqAkjfY6JISiLHgyNqicAC8AyHHGzNd/dA=="
     },
     "@commander-js/extra-typings": {
-      "version": "13.1.0",
-      "resolved": "https://registry.npmjs.org/@commander-js/extra-typings/-/extra-typings-13.1.0.tgz",
-      "integrity": "sha512-q5P52BYb1hwVWE6dtID7VvuJWrlfbCv4klj7BjUUOqMz4jbSZD4C9fJ9lRjL2jnBGTg+gDDlaXN51rkWcLk4fg==",
+      "version": "14.0.0",
+      "resolved": "https://registry.npmjs.org/@commander-js/extra-typings/-/extra-typings-14.0.0.tgz",
+      "integrity": "sha512-hIn0ncNaJRLkZrxBIp5AsW/eXEHNKYQBh0aPdoUqNgD+Io3NIykQqpKFyKcuasZhicGaEZJX/JBSIkZ4e5x8Dg==",
       "requires": {}
     },
     "@emnapi/core": {
@@ -3282,9 +3282,9 @@
       "dev": true
     },
     "commander": {
-      "version": "13.1.0",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-13.1.0.tgz",
-      "integrity": "sha512-/rFeCpNJQbhSZjGVwO9RFV3xPqbnERS8MmIQzCtD/zl6gpJuV/bMLuN92oG3F7d8oDEHHRrujSXNUr8fpjntKw==",
+      "version": "14.0.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-14.0.0.tgz",
+      "integrity": "sha512-2uM9rYjPvyq39NwLRqaiLtWHyDC1FvryJDa2ATTVims5YAS4PupsEQsDvP14FqhFr0P49CYDugi59xaxJlTXRA==",
       "peer": true
     },
     "concat-map": {

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
   "license": "MIT",
   "dependencies": {
     "@colors/colors": "^1.6.0",
-    "@commander-js/extra-typings": "^13.1.0",
+    "@commander-js/extra-typings": "^14.0.0",
     "cross-spawn": "^7.0.6",
     "extract-zip": "^2.0.1",
     "purify-ts": "^2.1.0",


### PR DESCRIPTION
Related issue: #28 

### Description
Upgrade `commander`to version 14 and test new group features

### Validations

- [ ] Run `npm run format` successfully
- [ ] Run `npm run build` successfully
- [ ] Run `npm run validate` successfully
- [ ] Run `npm run test` successfully

