### PR TITLE
GH-52: improve cleanup of previously installed version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unrelease Changes
 
 - Clean `--bin` directory before installing a new version of the dependency-check-cli.
+- Added parameter `--keep-old-versions` to prevent removal of other installations in `--bin` directory.
 
 ## Version 0.7.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unrelease Changes
+
+- Clean `--bin` directory before installing a new version of the dependency-check-cli.
+
 ## Version 0.7.0
 
 - The output of the `--version` parameter was fixed. It now displays the version of owasp-dependency-check instead of the version of the analyzed project.

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -28,6 +28,10 @@ const command = program
     "install the dependency-check CLI even if there already is one (will be overwritten)",
   )
   .option(
+    "--keep-old-versions",
+    "do not remove old versions of the dependency-check-cli",
+  )
+  .option(
     "--odc-version <version>",
     'the version of the dependency-check CLI to install in format "v1.2.3"',
   )
@@ -109,6 +113,7 @@ const cli = {
   projectName: getProjectName(),
   cmdArguments: buildCmdArguments(),
   ignoreErrors: !!command.opts().ignoreErrors,
+  keepOldVersions: !!command.opts().keepOldVersions,
 };
 
 export default cli;

--- a/src/dependency-check.ts
+++ b/src/dependency-check.ts
@@ -15,6 +15,7 @@ export async function run() {
         cli.proxyUrl,
         cli.githubToken,
         cli.forceInstall,
+        cli.keepOldVersions,
       ),
     );
   } else {

--- a/src/installer.ts
+++ b/src/installer.ts
@@ -133,5 +133,6 @@ export async function installDependencyCheck(
     return executable.unsafeCoerce();
   }
 
+  await cleanDir(binDir);
   return await installRelease(release, installDir, proxyUrl);
 }

--- a/src/installer.ts
+++ b/src/installer.ts
@@ -118,6 +118,7 @@ export async function installDependencyCheck(
   proxyUrl: Maybe<URL>,
   githubToken: Maybe<string>,
   forceInstall: boolean,
+  keepOldVersions: boolean,
 ) {
   const release = await findReleaseInfo(odcVersion, proxyUrl, githubToken);
   log(`Found release ${release.tag_name} on GitHub.`);
@@ -133,6 +134,8 @@ export async function installDependencyCheck(
     return executable.unsafeCoerce();
   }
 
-  await cleanDir(binDir);
+  if (!keepOldVersions) {
+    await cleanDir(binDir);
+  }
   return await installRelease(release, installDir, proxyUrl);
 }


### PR DESCRIPTION
Related issue: #52 

### Description
This removes old version of the dependency-check-cli when installing an update.

### Validations

- [x] Run `npm run format` successfully
- [x] Run `npm run build` successfully
- [x] Run `npm run validate` successfully
- [x] Run `npm run test` successfully

