### PR TITLE
GH-59: switch color library to ansis

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,8 +9,8 @@
       "version": "0.7.0",
       "license": "MIT",
       "dependencies": {
-        "@colors/colors": "^1.6.0",
         "@commander-js/extra-typings": "^13.1.0",
+        "ansis": "^4.1.0",
         "cross-spawn": "^7.0.6",
         "extract-zip": "^2.0.1",
         "purify-ts": "^2.1.0",
@@ -37,15 +37,6 @@
       },
       "engines": {
         "node": ">=18"
-      }
-    },
-    "node_modules/@colors/colors": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/@colors/colors/-/colors-1.6.0.tgz",
-      "integrity": "sha512-Ir+AOibqzrIsL6ajt3Rz3LskB7OiMVHqltZmspbW/TJuTVuyOMirVqAkjfY6JISiLHgyNqicAC8AyHHGzNd/dA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.1.90"
       }
     },
     "node_modules/@commander-js/extra-typings": {
@@ -964,6 +955,15 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/ansis": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/ansis/-/ansis-4.1.0.tgz",
+      "integrity": "sha512-BGcItUBWSMRgOCe+SVZJ+S7yTRG0eGt9cXAHev72yuGcY23hnLA7Bky5L/xLyPINoSN95geovfBkqoTlNZYa7w==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=14"
       }
     },
     "node_modules/argparse": {
@@ -2620,11 +2620,6 @@
     }
   },
   "dependencies": {
-    "@colors/colors": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/@colors/colors/-/colors-1.6.0.tgz",
-      "integrity": "sha512-Ir+AOibqzrIsL6ajt3Rz3LskB7OiMVHqltZmspbW/TJuTVuyOMirVqAkjfY6JISiLHgyNqicAC8AyHHGzNd/dA=="
-    },
     "@commander-js/extra-typings": {
       "version": "13.1.0",
       "resolved": "https://registry.npmjs.org/@commander-js/extra-typings/-/extra-typings-13.1.0.tgz",
@@ -3197,6 +3192,11 @@
         "json-schema-traverse": "^0.4.1",
         "uri-js": "^4.2.2"
       }
+    },
+    "ansis": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/ansis/-/ansis-4.1.0.tgz",
+      "integrity": "sha512-BGcItUBWSMRgOCe+SVZJ+S7yTRG0eGt9cXAHev72yuGcY23hnLA7Bky5L/xLyPINoSN95geovfBkqoTlNZYa7w=="
     },
     "argparse": {
       "version": "2.0.1",

--- a/package.json
+++ b/package.json
@@ -43,8 +43,8 @@
   },
   "license": "MIT",
   "dependencies": {
-    "@colors/colors": "^1.6.0",
     "@commander-js/extra-typings": "^13.1.0",
+    "ansis": "^4.1.0",
     "cross-spawn": "^7.0.6",
     "extract-zip": "^2.0.1",
     "purify-ts": "^2.1.0",
@@ -55,10 +55,10 @@
   },
   "main": "dist/dependency-check.js",
   "devDependencies": {
-    "@types/node": "^24.0.1",
-    "@types/cross-spawn": "^6.0.6",
     "@eslint/js": "^9.26.0",
     "@tsconfig/node18": "^18.2.4",
+    "@types/cross-spawn": "^6.0.6",
+    "@types/node": "^24.0.1",
     "@types/sinon": "^17.0.4",
     "eslint": "^9.29.0",
     "eslint-config-prettier": "^10.1.5",

--- a/src/executor.ts
+++ b/src/executor.ts
@@ -6,8 +6,8 @@ import {
   SpawnSyncOptionsWithStringEncoding,
 } from "child_process";
 import spawn from "cross-spawn";
-import colors from "@colors/colors/safe.js";
 import { Maybe } from "purify-ts";
+import { green } from "ansis";
 
 function executeVersionCheck(executable: string) {
   const versionCmdArguments = ["--version"];
@@ -75,7 +75,7 @@ function executeAnalysis(
     throw dependencyCheckSpawn.error;
   }
 
-  log(colors.green("Done."));
+  log(green`Done.`);
   return Maybe.fromNullable(dependencyCheckSpawn.status);
 }
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,6 +1,6 @@
 import extract from "extract-zip";
 import fs from "node:fs/promises";
-import { white} from "ansis";
+import { white } from "ansis";
 import { name } from "./info.js";
 
 export async function cleanDir(dir: string) {
@@ -28,9 +28,7 @@ export function log(...logData: string[]) {
 }
 
 function logWarning(...logData: string[]) {
-  console.log(
-    [white.bgYellow` WARNING: `, ...logData].join(" "),
-  );
+  console.log([white.bgYellow` WARNING: `, ...logData].join(" "));
 }
 
 export function logError(...logData: string[]) {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -19,12 +19,7 @@ async function deleteQuietly(path: string, recursive: boolean) {
 }
 
 export function log(...logData: string[]) {
-  console.log(
-    [
-      white.bgGreen` ${name}: `,
-      ...logData,
-    ].join(" "),
-  );
+  console.log([white.bgGreen` ${name}: `, ...logData].join(" "));
 }
 
 function logWarning(...logData: string[]) {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,6 +1,6 @@
-import colors from "@colors/colors/safe.js";
 import extract from "extract-zip";
 import fs from "node:fs/promises";
+import { white} from "ansis";
 import { name } from "./info.js";
 
 export async function cleanDir(dir: string) {
@@ -20,18 +20,21 @@ async function deleteQuietly(path: string, recursive: boolean) {
 
 export function log(...logData: string[]) {
   console.log(
-    [colors.bgGreen(colors.white(` ${name}: `)), ...logData].join(" "),
+    [
+      white.bgGreen` ${name}: `,
+      ...logData,
+    ].join(" "),
   );
 }
 
 function logWarning(...logData: string[]) {
   console.log(
-    [colors.bgYellow(colors.white(" WARNING: ")), ...logData].join(" "),
+    [white.bgYellow` WARNING: `, ...logData].join(" "),
   );
 }
 
 export function logError(...logData: string[]) {
-  console.error([colors.bgRed(colors.white(" ERROR: ")), ...logData].join(" "));
+  console.error([white.bgRed` ERROR: `, ...logData].join(" "));
 }
 
 export function ensureError(value: unknown): Error {


### PR DESCRIPTION
Related issue: #59 

### Description

Replace `@colors/colors` with `ansis`.

### Validations

- [x] Run `npm run format` successfully
- [x] Run `npm run build` successfully
- [x] Run `npm run validate` successfully
- [x] Run `npm run test` successfully
