### PR TITLE
GH-92: added parameter to set Java binary

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 - Added parameter `--keep-old-versions` to prevent removal of other installations in `--bin` directory.
 - The dependency `@colors/colors` has been replaced with `ansis`.
 - The dependency `commander` has been upgraded to version 14.
+- Added parameter `--java-bin` to set Java binary.\
+  This sets the `JAVACMD` environment variable before calling the dependency-check-cli.
 
 ## Version 0.7.1
 

--- a/src/dependency-check.ts
+++ b/src/dependency-check.ts
@@ -33,6 +33,7 @@ export async function run() {
       cli.outDir,
       cli.proxyUrl,
       cli.hideOwaspOutput,
+      cli.javaBinary,
     );
     exitProcess(result, cli.ignoreErrors, log);
   }

--- a/src/executor.ts
+++ b/src/executor.ts
@@ -19,6 +19,7 @@ function logCommandExecution(executable: string, cmdArguments: string[]) {
 
 function executeVersionCheck(executable: string) {
   const versionCmdArguments = ["--version"];
+  logCommandExecution(executable, versionCmdArguments);
 
   const versionSpawnOpts: SpawnSyncOptionsWithStringEncoding = {
     cwd: path.resolve(process.cwd()),
@@ -26,7 +27,6 @@ function executeVersionCheck(executable: string) {
     encoding: "utf-8",
   };
 
-  logCommandExecution(executable, versionCmdArguments);
   const versionSpawn = spawn.sync(
     executable,
     versionCmdArguments,
@@ -50,9 +50,8 @@ function executeAnalysis(
   proxyUrl: Maybe<URL>,
   hideOwaspOutput: boolean,
 ) {
-  const env = process.env;
   proxyUrl.ifJust((proxyUrl) => {
-    env.JAVA_OPTS = buildJavaToolOptions(proxyUrl);
+    process.env.JAVA_OPTS = buildJavaToolOptions(proxyUrl);
   });
 
   const dependencyCheckSpawnOpts: SpawnSyncOptions = {
@@ -84,9 +83,15 @@ export async function executeDependencyCheck(
   outDir: string,
   proxyUrl: Maybe<URL>,
   hideOwaspOutput: boolean,
+  javaBinary: Maybe<string>,
 ) {
   log.info("Dependency-Check Core path:", executable);
   await cleanDir(path.resolve(process.cwd(), outDir), log);
+
+  javaBinary.ifJust((javaBinary) => {
+    log.info("Using Java binary:", javaBinary);
+    process.env.JAVACMD = javaBinary;
+  });
 
   executeVersionCheck(executable);
   return executeAnalysis(executable, cmdArguments, proxyUrl, hideOwaspOutput);


### PR DESCRIPTION
Related issue: #92 

### Description
Added new parameter `--java-bin` to set Java binary to be used for executing ODC.

### Validations

- [x] Run `npm run format` successfully
- [x] Run `npm run build` successfully
- [x] Run `npm run validate` successfully
- [x] Run `npm run test` successfully

