### PR TITLE
Search for package manager's lock files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased Changes
+
+- Search for package managers' lock file if the `--scan` argument is not present.
+
 ## Version 0.8.1
 
 - Added `commander` as dependency to fix problems with `yarn`.

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -7,7 +7,7 @@ import path from "path";
 import os from "os";
 import fs from "fs";
 import { Maybe } from "purify-ts";
-import { ensureError } from "./utils.js";
+import { ensureError, resolveFile } from "./utils.js";
 import { description, name, version } from "./info.js";
 import { createLogger } from "./log.js";
 
@@ -86,7 +86,7 @@ const command = program
     "the location of the data directory used to store persistent data",
     path.join(os.tmpdir(), "dependency-check-data"),
   )
-  .option("-s, --scan <path...>", "the paths to scan ", ["package-lock.json"])
+  .option("-s, --scan <file...>", "the lock files of package managers to scan")
   .option("-f, --format <format...>", "the formats of the report to generate", [
     "HTML",
     "JSON",
@@ -114,7 +114,7 @@ Some defaults are provided:
 - project    Default: "name" from package.json in working directory
 - data       Default: dependency-check-data directory in system temp folder
 - format     Default: HTML and JSON
-- scan       Default: package-lock.json in working directory
+- scan       Default: package managers' lock files in working directory (package-lock.json, yarn.lock, pnpm-lock.yaml) 
 
 The following environment variables are supported:
 - OWASP_BIN: path to a local installation of the dependency-check-cli
@@ -122,25 +122,34 @@ The following environment variables are supported:
 - GITHUB_TOKEN: personal GitHub token to authenticate against API
 - PROJECT_NAME: the name of the project being scanned
 - JAVACMD: path to a Java binary`,
-  )
-  .parse();
+  );
 
-const cli = {
-  hideOwaspOutput: !!command.opts().hideOwaspOutput,
-  owaspBinary: Maybe.fromNullable(command.opts().owaspBin),
-  proxyUrl: Maybe.fromNullable(command.opts().proxy),
-  githubToken: Maybe.fromNullable(command.opts().githubToken),
-  outDir: command.opts().out,
-  forceInstall: !!command.opts().forceInstall,
-  odcVersion: Maybe.fromNullable(command.opts().odcVersion),
-  binDir: path.resolve(command.opts().bin),
-  cmdArguments: buildCmdArguments(),
-  ignoreErrors: !!command.opts().ignoreErrors,
-  keepOldVersions: !!command.opts().keepOldVersions,
-  javaBinary: Maybe.fromNullable(command.opts().javaBin),
-};
+export function parseCli() {
+  command.parse();
+  return {
+    hideOwaspOutput: !!command.opts().hideOwaspOutput,
+    owaspBinary: Maybe.fromNullable(command.opts().owaspBin),
+    proxyUrl: Maybe.fromNullable(command.opts().proxy),
+    githubToken: Maybe.fromNullable(command.opts().githubToken),
+    outDir: command.opts().out,
+    forceInstall: !!command.opts().forceInstall,
+    odcVersion: Maybe.fromNullable(command.opts().odcVersion),
+    binDir: path.resolve(command.opts().bin),
+    cmdArguments: buildCmdArguments(),
+    ignoreErrors: !!command.opts().ignoreErrors,
+    keepOldVersions: !!command.opts().keepOldVersions,
+    javaBinary: Maybe.fromNullable(command.opts().javaBin),
+  };
+}
 
-export default cli;
+function addScanArgument(args: string[], lockFile: string) {
+  resolveFile(lockFile).ifJust((value) => {
+    log.info(`Found ${lockFile} and adding it to --scan argument.`);
+    args.push("--scan", value);
+  });
+}
+
+const LOCK_FILES = ["package-lock.json", "yarn.lock", "pnpm-lock.yaml"];
 
 function buildCmdArguments() {
   const args = [
@@ -155,9 +164,16 @@ function buildCmdArguments() {
     args.push("--nvdApiKey", key);
   });
 
-  command.opts().scan.forEach((scan) => {
-    args.push("--scan", scan);
-  });
+  const scan = command.opts().scan;
+  if (scan) {
+    scan.forEach((scan) => {
+      args.push("--scan", scan);
+    });
+  } else {
+    LOCK_FILES.forEach((file) => {
+      addScanArgument(args, file);
+    });
+  }
 
   args.push(
     "--project",
@@ -199,14 +215,10 @@ function parseProxyUrl(value: string) {
 }
 
 function parseBinaryFile(value: string) {
-  const binPath = path.resolve(value);
-  if (fs.existsSync(binPath)) {
-    const stat = fs.statSync(binPath);
-    if (!stat.isFile()) {
-      throw new InvalidArgumentError("The binary is not a file.");
-    }
-  } else {
-    throw new InvalidArgumentError("The binary does not exist.");
-  }
-  return binPath;
+  const binPath = resolveFile(value);
+  return binPath
+    .ifNothing(() => {
+      throw new InvalidArgumentError("The binary file does not exist.");
+    })
+    .unsafeCoerce();
 }

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -90,6 +90,7 @@ const command = program
     "-s, --scan <file...>",
     "the lock files of package managers to scan",
     parseMultipleFiles,
+    [],
   )
   .option("-f, --format <format...>", "the formats of the report to generate", [
     "HTML",
@@ -169,7 +170,7 @@ function buildCmdArguments() {
   });
 
   const scan = command.opts().scan;
-  if (scan) {
+  if (scan.length > 0) {
     scan.forEach((scan) => {
       args.push("--scan", scan);
     });
@@ -218,9 +219,9 @@ function parseProxyUrl(value: string) {
   return url;
 }
 
-function parseMultipleFiles(value: string, previous: string[] | undefined) {
+function parseMultipleFiles(value: string, previous: string[]) {
   const file = parseFile(value);
-  return [...(previous ?? []), file];
+  return [...previous, file];
 }
 
 function parseFile(value: string) {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -218,9 +218,9 @@ function parseProxyUrl(value: string) {
   return url;
 }
 
-function parseMultipleFiles(value: string, previous: string[]) {
+function parseMultipleFiles(value: string, previous: string[] | undefined) {
   const file = parseFile(value);
-  return [...(previous ? previous : []), file];
+  return [...(previous ?? []), file];
 }
 
 function parseFile(value: string) {

--- a/src/dependency-check.ts
+++ b/src/dependency-check.ts
@@ -2,14 +2,19 @@
 import { ensureError, setExitCode } from "./utils.js";
 import { installDependencyCheck } from "./installer.js";
 import { executeDependencyCheck } from "./executor.js";
-import cli from "./cli.js";
+import { parseCli } from "./cli.js";
 import { Maybe } from "purify-ts";
 import { createLogger } from "./log.js";
 import { name } from "./info.js";
 
 const log = createLogger(name);
 
+let ignoreErrors = false;
+
 export async function run() {
+  const cli = parseCli();
+  ignoreErrors = cli.ignoreErrors;
+
   let executable = cli.owaspBinary;
   if (executable.isNothing()) {
     executable = Maybe.of(
@@ -35,12 +40,12 @@ export async function run() {
       cli.hideOwaspOutput,
       cli.javaBinary,
     );
-    setExitCode(result, cli.ignoreErrors, log);
+    setExitCode(result, ignoreErrors, log);
   }
 }
 
 void run().catch((e: unknown) => {
   const error = ensureError(e);
   log.error(error.message);
-  setExitCode(1, cli.ignoreErrors, log);
+  setExitCode(1, ignoreErrors, log);
 });


### PR DESCRIPTION
Related issue: #109 

### Description
If no `--scan` argument is given, search for the lock files of `npm`, `yarn` and `pnpm`. If they are present, pass them as `--scan` arguments to the dependency-check-cli.

### Validations

- [x] Run `npm run format` successfully
- [x] Run `npm run build` successfully
- [x] Run `npm run validate` successfully
- [x] Run `npm run test` successfully
