### PR TITLE
GH-125: fixed proxy config for Node 18 or 20

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,8 @@
 
 ## Unreleased Changes
 
-- Search for package managers' lock file if the `--scan` argument is not present.
+- Search for package managers' lock files if the `--scan` argument is not present.
+- Fixed incompatibility with Node 18/20 when using `--proxy` argument.
 
 ## Version 0.8.1
 

--- a/src/cli.spec.ts
+++ b/src/cli.spec.ts
@@ -1,0 +1,23 @@
+import { describe, it } from "node:test";
+import { parseProxyUrl } from "./cli.js";
+import assert from "node:assert/strict";
+import { InvalidArgumentError } from "@commander-js/extra-typings";
+
+void describe("cli.ts", () => {
+  void describe("parseProxyUrl", () => {
+    void it("should create a URL", () => {
+      const url = parseProxyUrl("http://user:password@server:8080");
+      assert.equal(url.protocol, "http:");
+      assert.equal(url.hostname, "server");
+      assert.equal(url.port, "8080");
+      assert.equal(url.username, "user");
+      assert.equal(url.password, "password");
+    });
+    void it("should throw an InvalidArgumentError if URL could not be parsed", () => {
+      assert.throws(
+        () => parseProxyUrl("htt\\p://user:password@server:8080"),
+        new InvalidArgumentError("The proxy URL is invalid."),
+      );
+    });
+  });
+});

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -7,7 +7,7 @@ import path from "node:path";
 import os from "node:os";
 import fs from "node:fs";
 import { Maybe } from "purify-ts";
-import { ensureError, resolveFile } from "./utils.js";
+import { ensureError, parseUrl, resolveFile } from "./utils.js";
 import { description, name, version } from "./info.js";
 import { createLogger } from "./log.js";
 
@@ -210,15 +210,11 @@ function getProjectNameFromPackageJson() {
   return projectName;
 }
 
-function parseProxyUrl(value: string) {
-  const url = URL.parse(value);
-  if (!url?.protocol || !url.hostname) {
-    throw new InvalidArgumentError("The proxy URL is invalid.");
-  }
-  if (url.protocol !== "http:" && url.protocol !== "https:") {
-    throw new InvalidArgumentError("The proxy URL is not HTTP(S).");
-  }
-  return url;
+export function parseProxyUrl(value: string) {
+  return parseUrl(value)
+    .filter(url => url.protocol === "http:" || url.protocol === "https:")
+    .toEither(new InvalidArgumentError("The proxy URL is invalid."))
+    .unsafeCoerce();
 }
 
 function parseFile(path: string) {

--- a/src/utils.spec.ts
+++ b/src/utils.spec.ts
@@ -6,6 +6,7 @@ import {
   setExitCode,
   hideSecrets,
   resolveFile,
+  parseUrl,
 } from "./utils.js";
 import sinon from "sinon";
 import fs, { Stats } from "node:fs";
@@ -176,6 +177,23 @@ void describe("utils.ts", () => {
       const file = resolveFile("test");
       assert.deepEqual(file, Maybe.of(path.resolve("test")));
       fsMock.verify();
+    });
+  });
+  void describe("parseUrl", () => {
+    void it("should return Nothing if the url is not valid", () => {
+      const url = parseUrl("htt\\p://user:password@server:8080");
+      assert.equal(url, Maybe.empty());
+    });
+    void it("should return an URL if the url is valid", () => {
+      const url = parseUrl("http://user:password@server:8080");
+      assert.notEqual(url, Maybe.empty());
+      url.ifJust(url => {
+        assert.equal(url.protocol, "http:");
+        assert.equal(url.hostname, "server");
+        assert.equal(url.port, "8080");
+        assert.equal(url.username, "user");
+        assert.equal(url.password, "password");
+      });
     });
   });
 });

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -88,3 +88,7 @@ export function fetchUrl(url: RequestInfo, init: RequestInit) {
 export function orThrow<T>(value: Maybe<T>, error: string): T {
   return value.toEither(new Error(error)).unsafeCoerce();
 }
+
+export function parseUrl(url: string) {
+  return Maybe.encase(() => new URL(url));
+}


### PR DESCRIPTION
Related issue: #125 

### Description
The function `URL.parse()` is only available from Node 22 onward. It has been replaced with a utility function around `new URL()`.

### Validations

- [x] Run `npm run format` successfully
- [x] Run `npm run build` successfully
- [x] Run `npm run validate` successfully
- [x] Run `npm run test` successfully

### Additional notes

- Some unit tests have also been added.