### PR TITLE
GH-171: read version from package.json and add it to project label

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Version 1.1.0
+
+- Added project's version to the `--project` argument.
+
 ## Version 1.0.0
 
 - The support for Node 18 has been dropped. The minimum required Node version is now 20.

--- a/src/util/misc.ts
+++ b/src/util/misc.ts
@@ -1,4 +1,6 @@
 import { Maybe } from "purify-ts";
+import fs from "node:fs";
+import * as yup from "yup";
 
 export function ensureError(error: unknown): Error {
   if (error instanceof Error) return error;
@@ -23,4 +25,18 @@ export function hideSecrets(input: string) {
 
 export function orThrow<T>(value: Maybe<T>, error: string): T {
   return value.toEither(new Error(error)).unsafeCoerce();
+}
+
+const packageInfoSchema = yup.object({
+  name: yup.string().required(),
+  version: yup.string().required(),
+});
+
+export function readPackageJson() {
+  return Maybe.encase(() => {
+    const packageJson = fs.readFileSync("package.json").toString();
+    return packageInfoSchema.validateSync(JSON.parse(packageJson), {
+      strict: true,
+    });
+  });
 }


### PR DESCRIPTION
Related issue: #171 

### Description

### Validations

- [x] Run `npm run format` successfully
- [x] Run `npm run build` successfully
- [x] Run `npm run validate` successfully
- [x] Run `npm run test` successfully
