### PR TITLE
do not ignore errors from fetch anymore

### DIFF
--- a/src/installer.spec.ts
+++ b/src/installer.spec.ts
@@ -76,7 +76,7 @@ void describe("installer.ts", () => {
         ],
       };
       const result = await castGithubRelease(data);
-      assert.ok(result.isJust());
+      assert.ok(result.isRight());
       assert.equal(result.unsafeCoerce().tag_name, "v2.0.0");
       assert.equal(
         result.unsafeCoerce().assets[0].name,
@@ -97,7 +97,7 @@ void describe("installer.ts", () => {
         ],
       };
       const result = await castGithubRelease(data);
-      assert.ok(result.isNothing());
+      assert.ok(result.isLeft());
     });
   });
 });

--- a/src/util/net.spec.ts
+++ b/src/util/net.spec.ts
@@ -31,7 +31,7 @@ void describe("util/net.ts", () => {
       const url = "https://example.com";
       const init = {};
       const result = await fetchUrl(url, init).run();
-      assert.ok(result.isJust());
+      assert.ok(result.isRight());
       undiciMock.verify();
     });
 
@@ -42,7 +42,7 @@ void describe("util/net.ts", () => {
       const url = "https://example.com";
       const init = {};
       const result = await fetchUrl(url, init).run();
-      assert.ok(result.isNothing());
+      assert.ok(result.isLeft());
       undiciMock.verify();
     });
 
@@ -52,7 +52,7 @@ void describe("util/net.ts", () => {
       const url = "https://example.com";
       const init = {};
       const result = await fetchUrl(url, init).run();
-      assert.ok(result.isNothing());
+      assert.ok(result.isLeft());
       undiciMock.verify();
     });
     void it("should return MaybeAsync with Nothing when rejects throws an error", async () => {
@@ -61,7 +61,7 @@ void describe("util/net.ts", () => {
       const url = "https://example.com";
       const init = {};
       const result = await fetchUrl(url, init).run();
-      assert.ok(result.isNothing());
+      assert.ok(result.isLeft());
       undiciMock.verify();
     });
   });
@@ -78,7 +78,7 @@ void describe("util/net.ts", () => {
       const url = "https://example.com";
       const init = {};
       const result = await fetchJson(url, init).run();
-      assert.ok(result.isJust());
+      assert.ok(result.isRight());
       assert.deepEqual(result.extract(), jsonData);
       undiciMock.verify();
     });
@@ -90,7 +90,7 @@ void describe("util/net.ts", () => {
       const url = "https://example.com";
       const init = {};
       const result = await fetchJson(url, init).run();
-      assert.ok(result.isNothing());
+      assert.ok(result.isLeft());
       undiciMock.verify();
     });
 
@@ -100,7 +100,7 @@ void describe("util/net.ts", () => {
       const url = "https://example.com";
       const init = {};
       const result = await fetchJson(url, init).run();
-      assert.ok(result.isNothing());
+      assert.ok(result.isLeft());
       undiciMock.verify();
     });
   });


### PR DESCRIPTION
Related issue:

### Description

### Validations

- [ ] Run `npm run format` successfully
- [ ] Run `npm run build` successfully
- [ ] Run `npm run validate` successfully
- [ ] Run `npm run test` successfully

### Additional notes

- Are there open topics?
- Are there other related issues or pull requests?
